### PR TITLE
Reduce API footprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,12 @@ How can I turn off auditing hooks for a method?
 ---
 
 You can remove the method from the test's [Set][] of
-`accessibility_audit_after_methods` configuration:
+`accessibility_audit_after_methods` configuration by calling
+`skip_accessibility_audit_after`:
 
 ```ruby
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  accessibility_audit_after_methods.delete :visit
+  skip_accessibility_audit_after :visit
 end
 ```
 

--- a/lib/capybara_accessibility_audit/auditor.rb
+++ b/lib/capybara_accessibility_audit/auditor.rb
@@ -1,0 +1,15 @@
+module CapybaraAccessibilityAudit
+  class Auditor
+    delegate_missing_to :@test
+
+    def initialize(test)
+      @test = test
+    end
+
+    def audit!(method)
+      if accessibility_audit_enabled && method.in?(accessibility_audit_after_methods)
+        assert_no_accessibility_violations(**accessibility_audit_options)
+      end
+    end
+  end
+end

--- a/test/system/audit_assertions_test.rb
+++ b/test/system/audit_assertions_test.rb
@@ -117,3 +117,17 @@ class SkippingAuditAssertionsTest < ApplicationSystemTestCase
     end
   end
 end
+
+class SkippingAuditAfterMethodTest < ApplicationSystemTestCase
+  skip_accessibility_audit_after :visit, :click_on
+
+  test "does not audit after a skipped method" do
+    visit violations_path
+    click_on "Violate rule: label"
+    go_back
+
+    assert_rule_violation("label: Form elements must have labels") do
+      click_link "Violate rule: label"
+    end
+  end
+end


### PR DESCRIPTION
Limit the overall impact on the methods declared in host application's
test suites. Remove the `#audit!` declaration, and delegate to a
`CapybaraAccessibilityAudit::Auditor` instance instead.

Introduce the `skip_accessibility_audit_after` class method to manage
the internal `accessibility_audit_after_methods` Set.