### PR TITLE
Add support for RSpec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,5 @@ jobs:
 
       - run: bin/rails standard
       - run: bin/rails test:all
+      - run: bundle exec rspec
+      - run: RSPEC_TYPE=feature bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ else
 end
 
 gem "rails", rails_constraint
+gem "rspec-rails"
 
 gem "puma"
 gem "standard", "~> 1.12"

--- a/lib/capybara_accessibility_audit/audit_system_test_extensions.rb
+++ b/lib/capybara_accessibility_audit/audit_system_test_extensions.rb
@@ -34,6 +34,8 @@ module CapybaraAccessibilityAudit
       end
     end
 
+    delegate :accessibility_audit_after, :skip_accessibility_audit_after, to: :class
+
     def with_accessibility_audits(**options, &block)
       accessibility_audit_enabled = self.accessibility_audit_enabled
       self.accessibility_audit_enabled = true

--- a/lib/capybara_accessibility_audit/auditor.rb
+++ b/lib/capybara_accessibility_audit/auditor.rb
@@ -7,8 +7,17 @@ module CapybaraAccessibilityAudit
     end
 
     def audit!(method)
-      if accessibility_audit_enabled && method.in?(accessibility_audit_after_methods)
+      if accessibility_audit_enabled && method.in?(accessibility_audit_after_methods) && javascript_enabled?
         assert_no_accessibility_violations(**accessibility_audit_options)
+      end
+    end
+
+    private
+
+    def javascript_enabled?
+      case page.driver
+      when Capybara::RackTest::Driver then false
+      else true
       end
     end
   end

--- a/lib/capybara_accessibility_audit/engine.rb
+++ b/lib/capybara_accessibility_audit/engine.rb
@@ -17,5 +17,21 @@ module CapybaraAccessibilityAudit
 
       accessibility_audit_after Rails.configuration.capybara_accessibility_audit.audit_after
     end
+
+    if defined?(RSpec)
+      RSpec.configure do |config|
+        config.include CapybaraAccessibilityAudit::AuditSystemTestExtensions, type: :system
+        config.include CapybaraAccessibilityAudit::AuditSystemTestExtensions, type: :feature
+
+        configure = proc do
+          self.accessibility_audit_enabled = Rails.configuration.capybara_accessibility_audit.audit_enabled
+
+          accessibility_audit_after Rails.configuration.capybara_accessibility_audit.audit_after
+        end
+
+        config.before(type: :system, &configure)
+        config.before(type: :feature, &configure)
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,24 @@
+# Configure Rails Environment
+ENV["RAILS_ENV"] = "test"
+
+require_relative "../test/dummy/config/application"
+require "capybara_accessibility_audit"
+require "rspec/rails"
+
+Dummy::Application.initialize!
+
+module FeatureSpecBackports
+  def driven_by(name, **)
+    Capybara.current_driver = Capybara.javascript_driver = name
+  end
+end
+
+RSpec.configure do |config|
+  config.use_active_record = false
+
+  config.filter_rails_from_backtrace!
+
+  config.include FeatureSpecBackports, type: :feature
+end
+
+Capybara.server = :puma, {Silent: true}

--- a/spec/system/audit_assertions_spec.rb
+++ b/spec/system/audit_assertions_spec.rb
@@ -1,0 +1,166 @@
+require "spec_helper"
+
+RSpec.describe "Audit assertions", type: ENV.fetch("RSPEC_TYPE", "system") do
+  before do
+    driven_by :selenium_headless, using: :headless_chrome, screen_size: [1400, 1400]
+  end
+
+  it "flunks on violations detected after #visit" do
+    assert_rule_violation "label: Form elements must have labels" do
+      visit violations_path(rules: %w[label])
+    end
+  end
+
+  it "flunks on violations detected after #click_on" do
+    visit violations_path
+
+    assert_rule_violation "label: Form elements must have labels" do
+      click_on "Violate rule: label"
+    end
+  end
+
+  it "flunks on violations detected after #click_link" do
+    visit violations_path
+
+    assert_rule_violation "label: Form elements must have labels" do
+      click_link "Violate rule: label"
+    end
+  end
+
+  it "flunks on violations detected after #click_button" do
+    visit violations_path
+    fill_in "Rules to violate", with: "label"
+
+    assert_rule_violation "label: Form elements must have labels" do
+      click_button "Submit"
+    end
+  end
+
+  it "flunks on violations detected after #click_link_or_button" do
+    visit violations_path
+
+    assert_rule_violation "label: Form elements must have labels" do
+      click_link_or_button "Violate rule: label"
+    end
+  end
+
+  it "ignores violations within a matching skip_accessibility_violations block" do
+    skip_accessibility_violations("label") { visit violations_path(rules: %w[label]) }
+    skip_accessibility_violations(%w[label]) { visit violations_path(rules: %w[label]) }
+  end
+
+  it "raises violations within a skip_accessibility_violation block that does not apply" do
+    skip_accessibility_violations "label" do
+      assert_rule_violation "image-alt: Images must have alternate text" do
+        visit violations_path(rules: %w[image-alt])
+      end
+    end
+  end
+
+  describe "Disabling" do
+    before do
+      self.accessibility_audit_enabled = false
+    end
+
+    it "ignores violations" do
+      visit violations_path
+      click_on "Violate rule: label"
+      go_back
+      click_on "Violate rule: image-alt"
+    end
+
+    it "flunks on calls within with_accessibility_audits" do
+      with_accessibility_audits do
+        assert_rule_violation "label: Form elements must have labels" do
+          visit violations_path(rules: %w[label])
+        end
+      end
+    end
+
+    it "flunks on calls within with_accessibility_audits based on options" do
+      visit violations_path
+
+      with_accessibility_audits skipping: "label" do
+        click_on "Violate rule: label"
+      end
+
+      go_back
+
+      with_accessibility_audits do
+        assert_rule_violation "image-alt: Images must have alternate text" do
+          click_on "Violate rule: image-alt"
+        end
+      end
+    end
+
+    it "flunks on calls to assert_no_accessibility_violations" do
+      visit violations_path(rules: %w[label image-alt])
+
+      assert_rule_violation(
+        with: "label: Form elements must have labels",
+        without: "image-alt: Images must have alternate text"
+      ) do
+        assert_no_accessibility_violations checking: "label", skipping: "image-alt"
+      end
+    end
+  end
+
+  describe "Skipping" do
+    before do
+      accessibility_audit_options.skipping = %w[label]
+    end
+
+    it "ignores violations" do
+      visit violations_path
+      click_on "Violate rule: label"
+    end
+
+    it "calls to with_accessibility_audit_options merge options" do
+      with_accessibility_audit_options excluding: "img" do
+        visit violations_path
+        click_on "Violate rule: label"
+        go_back
+        click_on "Violate rule: image-alt"
+      end
+    end
+  end
+
+  describe "Skipping audit after method" do
+    before do
+      skip_accessibility_audit_after :visit, :click_on
+    end
+
+    it "does not audit after a skipped method" do
+      visit violations_path
+      click_on "Violate rule: label"
+      go_back
+
+      assert_rule_violation("label: Form elements must have labels") do
+        click_link "Violate rule: label"
+      end
+    end
+  end
+
+  describe "Skipping rack_test drivers" do
+    before do
+      driven_by :rack_test
+    end
+
+    it "ignores violations" do
+      visit violations_path
+      click_on "Violate rule: label"
+    end
+  end
+
+  def assert_rule_violation(rule = nil, with: rule, without: nil, &block)
+    exception = assert_raises(Minitest::Assertion, &block)
+
+    Array(with).flatten.each do |included|
+      expect(exception.message).to include(included)
+    end
+
+    Array(without).flatten.each do |excluded|
+      expect(exception.message).not_to include(excluded)
+    end
+  end
+end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  driven_by :selenium_headless, using: :headless_chrome, screen_size: [1400, 1400]
 
   def self.debug!
     driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/system/audit_assertions_test.rb
+++ b/test/system/audit_assertions_test.rb
@@ -131,3 +131,12 @@ class SkippingAuditAfterMethodTest < ApplicationSystemTestCase
     end
   end
 end
+
+class SkippingRackTestDriversTest < ApplicationSystemTestCase
+  driven_by :rack_test
+
+  test "ignores violations" do
+    visit violations_path
+    click_on "Violate rule: label"
+  end
+end


### PR DESCRIPTION
Introduce the RSpec-focused `spec/` directory to mirror the
MiniTest-focused `test/` directory, and configure our Continuous
Integration system to execute that suite as well.

Since RSpec `type: :feature` tests default to execute without
JavaScript, first check for a JavaScript-capable browser before
executing an audit.