### PR TITLE
Improve coverage for `skip_accessibility_audits`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,26 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 end
 ```
 
+How can I turn off auditing for a block of code?
+---
+
+You can disable automated auditing temporarily by wrapping code in a
+`skip_accessibility_audits` block:
+
+```ruby
+class MySystemTest < ApplicationSystemTestCase
+  test "with overridden accessibility audit options" do
+    skip_accessibility_audits do
+      visit a_page_with_violations_path
+
+      click_on "A link to a page with a violation"
+    end
+
+    # ...
+  end
+end
+```
+
 How can I turn off auditing hooks for a method?
 ---
 

--- a/spec/system/audit_assertions_spec.rb
+++ b/spec/system/audit_assertions_spec.rb
@@ -57,6 +57,12 @@ RSpec.describe "Audit assertions", type: ENV.fetch("RSPEC_TYPE", "system") do
     end
   end
 
+  it "ignores violations when wrapped in skip_accessibility_audits" do
+    skip_accessibility_audits do
+      visit violations_path(rules: %w[label])
+    end
+  end
+
   describe "Disabling" do
     before do
       self.accessibility_audit_enabled = false

--- a/test/system/audit_assertions_test.rb
+++ b/test/system/audit_assertions_test.rb
@@ -45,6 +45,12 @@ class AuditAssertionsTest < ApplicationSystemTestCase
     skip_accessibility_violations(%w[label]) { visit violations_path(rules: %w[label]) }
   end
 
+  test "ignores violations when wrapped in skip_accessibility_audits" do
+    skip_accessibility_audits do
+      visit violations_path(rules: %w[label])
+    end
+  end
+
   test "raises violations within a skip_accessibility_violation block that does not apply" do
     skip_accessibility_violations "label" do
       assert_rule_violation "image-alt: Images must have alternate text" do


### PR DESCRIPTION
Expand test suite coverage for `skip_accessibility_audits`, and explain
how to use it in the Frequently Asked Questions section of the README.