### PR TITLE
Work around `accept_modal` quirks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Support Capybara's modal block helpers like [accept_alert][]
+
+  *Sean Doyle*
+
+[accept_alert]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Session:accept_alert
+
 ## 0.1.0
 
 - Initial release

--- a/test/dummy/app/views/violations/index.html.erb
+++ b/test/dummy/app/views/violations/index.html.erb
@@ -11,6 +11,10 @@
 
     <button>Submit</button>
   </form>
+
+  <button type="button" onclick="alert('<%= params.fetch(:alert, "Alert!") %>')">Open alert</button>
+  <button type="button" onclick="confirm('<%= params.fetch(:confirm, "Confirm?") %>')">Open confirm</button>
+  <button type="button" onclick="prompt('<%= params.fetch(:prompt, "Hello?") %>')">Open prompt</button>
 <% end %>
 
 <% if @violations.label? %>

--- a/test/system/audit_assertions_test.rb
+++ b/test/system/audit_assertions_test.rb
@@ -58,6 +58,26 @@ class AuditAssertionsTest < ApplicationSystemTestCase
       end
     end
   end
+
+  test "gracefully handles accept_alert blocks" do
+    visit violations_path(alert: "Alert!")
+
+    accept_alert("Alert!") { click_button "Open alert" }
+  end
+
+  test "gracefully handles confirm blocks" do
+    visit violations_path(confirm: "Confirm?")
+
+    accept_confirm("Confirm?") { click_button "Open confirm" }
+    dismiss_confirm("Confirm?") { click_button "Open confirm" }
+  end
+
+  test "gracefully handles prompt blocks" do
+    visit violations_path(prompt: "Hello?")
+
+    accept_prompt("Hello?") { click_button "Open prompt" }
+    dismiss_prompt("Hello?") { click_button "Open prompt" }
+  end
 end
 
 class DisablingAuditAssertionsTest < ApplicationSystemTestCase


### PR DESCRIPTION
Prior to this change, calling a Capybara modal helper like [accept_alert][] would raise an error like:

```
Selenium::WebDriver::Error::UnexpectedAlertOpenError: unexpected alert open: {Alert text : Are you sure?}
```

To resolve that issue, skip accessibility auditing for the duration of the block, then execute an audit when the block is finished being executed.

[accept_alert]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Session:accept_alert