### PR TITLE
Specify minimum Ruby and Rails versions

### DIFF
--- a/capybara_accessibility_audit.gemspec
+++ b/capybara_accessibility_audit.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Accessibility tooling for Capybara"
   spec.description = "Accessibility tooling for Capybara"
   spec.license = "MIT"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/thoughtbot/capybara_accessibility_audit"
@@ -18,7 +19,7 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails"
+  spec.add_dependency "rails", ">= 6.1"
   spec.add_dependency "capybara"
   spec.add_dependency "axe-core-capybara"
   spec.add_dependency "zeitwerk"


### PR DESCRIPTION
Closes [#10][]
Closes [#11][]

The gem officially supports Ruby >= 2.7 and Rails 6.1.

[#10]: https://github.com/thoughtbot/capybara_accessibility_audit/issues/10
[#11]: https://github.com/thoughtbot/capybara_accessibility_audit/issues/11