### PR TITLE
Allow `assert_no_accessibility_violations` to accept block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Allow `assert_no_accessibility_violations` to accept a `block`
+
+  *Steve Polito*
+
 ## 0.1.1 (September 26, 2023)
 
 - Support Capybara's modal block helpers like [accept_alert][]

--- a/README.md
+++ b/README.md
@@ -204,6 +204,21 @@ class MySystemTest < ApplicationSystemTestCase
 end
 ```
 
+How can I simply assert that a page raises no violations?
+---
+
+There may be cases where you wish to assert that a page raises no violations.
+
+```ruby
+class MySystemTest < ApplicationSystemTestCase
+  test "Page raises no accessibility violations" do
+    assert_no_accessibility_violations do
+      visit root_path
+    end
+  end
+end
+```
+
 ## Installation
 Add this line to your application's Gemfile:
 

--- a/lib/capybara_accessibility_audit/audit_system_test_extensions.rb
+++ b/lib/capybara_accessibility_audit/audit_system_test_extensions.rb
@@ -90,7 +90,7 @@ module CapybaraAccessibilityAudit
       accessibility_audit_options.skipping = skipping
     end
 
-    def assert_no_accessibility_violations(**options)
+    def assert_no_accessibility_violations(**options, &block)
       options.assert_valid_keys(
         :according_to,
         :checking,
@@ -103,6 +103,8 @@ module CapybaraAccessibilityAudit
 
       axe_matcher = Axe::Matchers::BeAxeClean.new
       axe_matcher = options.inject(axe_matcher) { |matcher, option| matcher.public_send(*option) }
+
+      yield if block
 
       assert axe_matcher.matches?(page), axe_matcher.failure_message
     end

--- a/test/system/audit_assertions_test.rb
+++ b/test/system/audit_assertions_test.rb
@@ -124,6 +124,12 @@ class DisablingAuditAssertionsTest < ApplicationSystemTestCase
       assert_no_accessibility_violations checking: "label", skipping: "image-alt"
     end
   end
+
+  test "assert_no_accessibility_violations takes block" do
+    assert_no_accessibility_violations do
+      visit violations_path
+    end
+  end
 end
 
 class SkippingAuditAssertionsTest < ApplicationSystemTestCase


### PR DESCRIPTION
There might be cases where you wish to see if a page raises any
violations. Simply visiting a page with violations will fail, but it
could be nice to declare that in the test itself.

One possible use-case could be visiting a page that requires no
user interactions. A controller level test might cover the markup, but
the system level test would be created for testing accessibility
violations.
