### PR TITLE
Remove unused `axe-capybara` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove unused `require "axe-capybara"` statement
+
+  *Sean Doyle*
+
 - Drop support for [End of Life version 2.7](https://www.ruby-lang.org/en/downloads/branches/)
 
   *Sean Doyle*

--- a/capybara_accessibility_audit.gemspec
+++ b/capybara_accessibility_audit.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.1"
   spec.add_dependency "capybara"
-  spec.add_dependency "axe-core-capybara"
+  spec.add_dependency "axe-core-api"
   spec.add_dependency "zeitwerk"
 end

--- a/lib/capybara_accessibility_audit/audit_system_test_extensions.rb
+++ b/lib/capybara_accessibility_audit/audit_system_test_extensions.rb
@@ -1,4 +1,3 @@
-require "axe-capybara"
 require "axe/matchers/be_axe_clean"
 
 module CapybaraAccessibilityAudit


### PR DESCRIPTION
The contents of the [axe-capybara.rb][] file aren't necessary for `capybara_accessibility_audit`'s pattern of usage.

This also sheds an indirect and unstated `selenium-webdrivers` dependency.

[axe-capybara.rb]: https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-capybara/lib/axe-capybara.rb