### PR TITLE
Codify Ruby 3.0 requirement into gemspec

### DIFF
--- a/capybara_accessibility_audit.gemspec
+++ b/capybara_accessibility_audit.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Accessibility tooling for Capybara"
   spec.description = "Accessibility tooling for Capybara"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/thoughtbot/capybara_accessibility_audit"


### PR DESCRIPTION
Follow up to [#18][]

The changes made in #18 removed `ruby@2.7` from the CI matrix, but the support range was not codified into the gemspec. This commit declares an explicit requirement on at least `ruby@3.0`.

[#18]: https://github.com/thoughtbot/capybara_accessibility_audit/pull/18