### PR TITLE
Allow marking tests Pending when they fail audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 end
 ```
 
+How can I make all of the failing tests just be pending instead of failures?
+---
+
+You can allow automated auditing, but mark tests that fail the auditing be marked as `pending` instead of `failed`:
+
+```ruby
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  self.accessibility_audit_skip_on_error = true
+end
+```
+
 How can I turn off auditing for a block of code?
 ---
 

--- a/spec/system/audit_assertions_spec.rb
+++ b/spec/system/audit_assertions_spec.rb
@@ -63,6 +63,20 @@ RSpec.describe "Audit assertions", type: ENV.fetch("RSPEC_TYPE", "system") do
     end
   end
 
+  describe "Make failing tests Pending" do
+    before do
+      self.accessibility_audit_skip_on_error = true
+    end
+
+    it "marks violation test as pending" do
+      allow_any_instance_of(RSpec::Core::Pending).to receive(:skip)
+      visit violations_path
+      click_on "Violate rule: label"
+      go_back
+      click_on "Violate rule: image-alt"
+    end
+  end
+
   describe "Disabling" do
     before do
       self.accessibility_audit_enabled = false


### PR DESCRIPTION
Works on #21.  This is a draft, mostly to start the conversation for one way this could work.

This doesn't completely fix the problem that is identified in #21, but it is a step in that direction.  The idea is that, if the configuration setting `accessibility_audit_skip_on_error` is set to true, if an `axe` violation is detected, instead of generating an error it will instead mark the test as `skipped` with the `axe` output as the message in the skip output.

There is a problem with this approach, which is the same problem identified in issue #7 - as soon as a single test is marked skipped or failed, then the rest of the test is skipped.  This means that if a test has both failing application logic and failing accessibility validation, the first of those tests to fail will be the one that is reported.  For a system test, since any interaction with the page will trigger the accessibility tests, it is likely that the test will be marked as skipped and the application logic failure will be hidden.

This can be solved by running the tests a second time with `accessibility_audit_enabled = false` and comparing the results, but that does require two runs through the test suite.