### PR TITLE
Fix failing tests and warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,24 @@ jobs:
           - "3.1"
           - "3.2"
         rails-version:
+          - "8.0"
+          - "7.2"
           - "7.1"
           - "7.0"
           - "6.1"
           - "main"
         exclude:
           - ruby-version: "3.0"
+            rails-version: "7.2"
+          - ruby-version: "3.0"
+            rails-version: "8.0"
+          - ruby-version: "3.0"
+            rails-version: "main"
+          - ruby-version: "3.1"
+            rails-version: "7.2"
+          - ruby-version: "3.1"
+            rails-version: "8.0"
+          - ruby-version: "3.1"
             rails-version: "main"
 
     env:

--- a/capybara_accessibility_audit.gemspec
+++ b/capybara_accessibility_audit.gemspec
@@ -23,4 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "capybara"
   spec.add_dependency "axe-core-api"
   spec.add_dependency "zeitwerk"
+
+  spec.add_dependency "bigdecimal"
+  spec.add_dependency "drb"
+  spec.add_dependency "mutex_m"
 end

--- a/spec/system/audit_assertions_spec.rb
+++ b/spec/system/audit_assertions_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Audit assertions", type: ENV.fetch("RSPEC_TYPE", "system") do
 
   it "raises violations within a skip_accessibility_violation block that does not apply" do
     skip_accessibility_violations "label" do
-      assert_rule_violation "image-alt: Images must have alternate text" do
+      assert_rule_violation "image-alt: Images must have alternative text" do
         visit violations_path(rules: %w[image-alt])
       end
     end
@@ -93,7 +93,7 @@ RSpec.describe "Audit assertions", type: ENV.fetch("RSPEC_TYPE", "system") do
       go_back
 
       with_accessibility_audits do
-        assert_rule_violation "image-alt: Images must have alternate text" do
+        assert_rule_violation "image-alt: Images must have alternative text" do
           click_on "Violate rule: image-alt"
         end
       end
@@ -104,7 +104,7 @@ RSpec.describe "Audit assertions", type: ENV.fetch("RSPEC_TYPE", "system") do
 
       assert_rule_violation(
         with: "label: Form elements must have labels",
-        without: "image-alt: Images must have alternate text"
+        without: "image-alt: Images must have alternative text"
       ) do
         assert_no_accessibility_violations checking: "label", skipping: "image-alt"
       end

--- a/test/system/audit_assertions_test.rb
+++ b/test/system/audit_assertions_test.rb
@@ -53,7 +53,7 @@ class AuditAssertionsTest < ApplicationSystemTestCase
 
   test "raises violations within a skip_accessibility_violation block that does not apply" do
     skip_accessibility_violations "label" do
-      assert_rule_violation "image-alt: Images must have alternate text" do
+      assert_rule_violation "image-alt: Images must have alternative text" do
         visit violations_path(rules: %w[image-alt])
       end
     end
@@ -108,7 +108,7 @@ class DisablingAuditAssertionsTest < ApplicationSystemTestCase
     go_back
 
     with_accessibility_audits do
-      assert_rule_violation "image-alt: Images must have alternate text" do
+      assert_rule_violation "image-alt: Images must have alternative text" do
         click_on "Violate rule: image-alt"
       end
     end
@@ -119,7 +119,7 @@ class DisablingAuditAssertionsTest < ApplicationSystemTestCase
 
     assert_rule_violation(
       with: "label: Form elements must have labels",
-      without: "image-alt: Images must have alternate text"
+      without: "image-alt: Images must have alternative text"
     ) do
       assert_no_accessibility_violations checking: "label", skipping: "image-alt"
     end


### PR DESCRIPTION
**This PR:**
- Fixes failing tests (and some that are passing) by updating the error text from `image-alt` a11y errors
- Fixes warnings when running `bin/rails test:all`:
```
/Users/username/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/activesupport-7.0.8.6/lib/active_support/core_ext/object.rb:13: 
warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems 
starting from Ruby 3.4.0.
You can add bigdecimal to your Gemfile or gemspec to silence this warning.

/Users/username/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/activesupport-7.0.8.6/lib/active_support/
notifications.rb:4: 
warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems 
starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.

/Users/username/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/activesupport-7.0.8.6/lib/active_support/testing/
parallelization.rb:3: 
warning: drb was loaded from the standard library, but will no longer be part of the default gems 
starting from Ruby 3.4.0.
You can add drb to your Gemfile or gemspec to silence this warning.
```
- Adds `node_modules` and `yarn.lock` to `.gitignore`