### PR TITLE
Fix support for Capybara Playwright driver

### DIFF
--- a/lib/capybara_accessibility_audit/axe_auditor.rb
+++ b/lib/capybara_accessibility_audit/axe_auditor.rb
@@ -29,7 +29,18 @@ module CapybaraAccessibilityAudit
     def run(config)
       context, options = split(config)
 
-      page.evaluate_async_script <<~JS, context.to_h, options.to_h
+      # Convert to JSON-compatible hashes (all symbols become strings)
+      # Playwright driver can’t serialize Ruby symbols, e.g.
+      #
+      #   accessibility_audit_options.according_to = [
+      #     :wcag2a,
+      #     :wcag2aa
+      #   ]
+      #
+      context_hash = context.to_h.as_json
+      options_hash = options.to_h.as_json
+
+      page.evaluate_async_script <<~JS, context_hash, options_hash
         const [ context, options, callback ] = arguments
 
         axe.run(context, options).then(callback)

--- a/lib/capybara_accessibility_audit/axe_auditor.rb
+++ b/lib/capybara_accessibility_audit/axe_auditor.rb
@@ -8,7 +8,7 @@ module CapybaraAccessibilityAudit
     class_attribute :source, instance_accessor: false, default: Axe::Configuration.instance.jslib
 
     def initialize(page, reporter)
-      @page = page
+      @page_proc = page.is_a?(Proc) ? page : -> { page }
       @reporter = reporter
     end
 
@@ -22,10 +22,14 @@ module CapybaraAccessibilityAudit
 
     private
 
+    def page
+      @page_proc.call
+    end
+
     def run(config)
       context, options = split(config)
 
-      @page.evaluate_async_script <<~JS, context.to_h, options.to_h
+      page.evaluate_async_script <<~JS, context.to_h, options.to_h
         const [ context, options, callback ] = arguments
 
         axe.run(context, options).then(callback)
@@ -47,11 +51,11 @@ module CapybaraAccessibilityAudit
     end
 
     def install
-      @page.execute_script(self.class.source) unless installed?
+      page.execute_script(self.class.source) unless installed?
     end
 
     def installed?
-      @page.evaluate_script <<~JS
+      page.evaluate_script <<~JS
         "axe" in window && typeof axe.run === "function"
       JS
     end

--- a/lib/capybara_accessibility_audit/engine.rb
+++ b/lib/capybara_accessibility_audit/engine.rb
@@ -25,7 +25,7 @@ module CapybaraAccessibilityAudit
           auditor_class = app.config.capybara_accessibility_audit.auditor
           reporter_class = CapybaraAccessibilityAudit.reporter_class(accessibility_audit_reporter)
 
-          self.accessibility_audit_auditor = auditor_class.new(page, reporter_class.new(self))
+          self.accessibility_audit_auditor = auditor_class.new(-> { page }, reporter_class.new(self))
         end
       end
     end
@@ -46,7 +46,7 @@ module CapybaraAccessibilityAudit
             auditor_class = app.config.capybara_accessibility_audit.auditor
             reporter_class = CapybaraAccessibilityAudit.reporter_class(accessibility_audit_reporter)
 
-            self.accessibility_audit_auditor = auditor_class.new(page, reporter_class.new(self))
+            self.accessibility_audit_auditor = auditor_class.new(-> { page }, reporter_class.new(self))
           end
 
           config.before(type: :system, &configure)


### PR DESCRIPTION
## Summary

Fixes support for the Capybara Playwright driver by addressing two compatibility issues:

1. **Driver resolution timing**: The `page` object was being bound too early during test setup, capturing the `RackTest::Driver` instead of the actual driver (e.g., `Playwright::Driver`) used at runtime.

2. **Symbol serialization**: Playwright's `evaluate_async_script` cannot serialize Ruby symbols, causing errors when passing axe-core configuration options like `[:wcag2a, :wcag2aa]`.

## Testing

These changes allow the Playwright driver to work correctly without affecting existing RackTest and Selenium driver support as tested on the CollegeVine Rails project.