### PR TITLE
Require MFA for gem pushes

### DIFF
--- a/capybara_accessibility_audit.gemspec
+++ b/capybara_accessibility_audit.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/thoughtbot/capybara_accessibility_audit"
   spec.metadata["changelog_uri"] = "https://github.com/thoughtbot/capybara_accessibility_audit/blob/main/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]


### PR DESCRIPTION
This adds the `rubygems_mfa_required` metadata to the gemspec, requiring multi-factor authentication for privileged operations on RubyGems.org.

This is a protection against supply chain attacks like the recent NPM Axios compromise: https://socket.dev/blog/axios-npm-package-compromised

Reference: https://guides.rubygems.org/mfa-requirement-opt-in/